### PR TITLE
media: drop byte typedef

### DIFF
--- a/mm-video-v4l2/vidc/vdec/inc/mp4_utils.h
+++ b/mm-video-v4l2/vidc/vdec/inc/mp4_utils.h
@@ -38,7 +38,6 @@ typedef int int32;   /* Signed 32 bit value */
 typedef signed short int16;   /* Signed 16 bit value */
 typedef signed char int8;   /* Signed 8  bit value */
 
-typedef unsigned char byte;   /* Unsigned 8  bit value type. */
 #define SIMPLE_PROFILE_LEVEL0            0x08
 #define SIMPLE_PROFILE_LEVEL1            0x01
 #define SIMPLE_PROFILE_LEVEL2            0x02
@@ -154,7 +153,7 @@ class MP4_Utils
         };
 
         posInfoType m_posInfo;
-        byte *m_dataBeginPtr;
+        uint8 *m_dataBeginPtr;
         unsigned int vop_time_resolution;
         bool vop_time_found;
         uint16 m_SrcWidth, m_SrcHeight;   // Dimensions of the source clip


### PR DESCRIPTION
 * C++17 defines std::byte, making references to 'byte' ambiguous

 * Replace instances of 'byte' by 'uint8'

Change-Id: I0efc6bfcbe0e6710ae943941f5a3e1b2a8ac48b8